### PR TITLE
書籍詳細のリスト作成を直前に修正

### DIFF
--- a/cr_bookmeter/bookmeter_crawl.py
+++ b/cr_bookmeter/bookmeter_crawl.py
@@ -67,7 +67,7 @@ def get_urls_for_detail_crawl():
         return sorted(list(set(urls)))
 
 @defer.inlineCallbacks
-def run_crawls(runner, args, urls_to_crawl):
+def run_crawls(runner, args):
     """クローリングを順次実行する"""
     if args.stacked:
         logger.info("積読本リストの取得を開始します。")
@@ -77,10 +77,15 @@ def run_crawls(runner, args, urls_to_crawl):
         logger.info("読んだ本リストの取得を開始します。")
         yield runner.crawl(BookmeterReadSpider)
 
-    if args.detail and urls_to_crawl:
-        logger.info("書籍詳細の取得準備を開始します。")
-        logger.info(f"詳細未取得の書籍が {len(urls_to_crawl)} 件見つかりました。クロールを開始します。")
-        yield runner.crawl(BookmeterBookDetailSpider, target_urls=urls_to_crawl)
+    if args.detail:
+        # 積読・読了リストの更新が終わった後の最新状態で、詳細未取得のURLを再取得する
+        urls_to_crawl = get_urls_for_detail_crawl()
+        if urls_to_crawl:
+            logger.info("書籍詳細の取得準備を開始します。")
+            logger.info(f"詳細未取得の書籍が {len(urls_to_crawl)} 件見つかりました。クロールを開始します。")
+            yield runner.crawl(BookmeterBookDetailSpider, target_urls=urls_to_crawl)
+        else:
+            logger.info("DBに存在する書籍はすべて詳細取得済みです。")
 
 
 def handle_delete_details():
@@ -362,13 +367,8 @@ def main():
 
     initialize_database()
 
-    # クロールが必要かどうかを事前に判断する
-    urls_for_detail = []
-    if args.detail:
-        urls_for_detail = get_urls_for_detail_crawl()
-
-    # クロール処理が必要な場合のみ Scrapy と Twisted をセットアップ
-    if args.stacked or args.read or (args.detail and urls_for_detail):
+    # クロール処理が必要な場合（いずれかのフラグが立っている場合）
+    if args.stacked or args.read or args.detail:
         settings = get_project_settings()
         from scrapy.utils.reactor import install_reactor
         install_reactor(settings.get("TWISTED_REACTOR"))
@@ -377,13 +377,10 @@ def main():
         runner = CrawlerRunner(settings)
         
         logger.info("クローリング処理を開始します...")
-        d = run_crawls(runner, args, urls_for_detail)
+        d = run_crawls(runner, args)
         d.addBoth(lambda _: reactor.stop())
         reactor.run()
         logger.info("クローリング処理が完了しました。")
-    elif args.detail and not urls_for_detail:
-        # -dt のみ指定され、クロール対象がない場合のメッセージ
-        logger.info("DBに存在する書籍はすべて詳細取得済みです。")
 
     if args.deletedetail:
         handle_delete_details()


### PR DESCRIPTION
-allオプションで実行した際、書籍詳細リストの作成を最初に行っていたため先に実行した-st, -rdの結果が反映されていない状態で-dtの未処理リストを作成してしまっていたので順番を修正