### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,6 +5,8 @@ on:
       - main
   pull_request:
     types: [opened, synchronize, reopened]
+permissions:
+  contents: read
 jobs:
   sonarqube:
     name: SonarQube


### PR DESCRIPTION
Potential fix for [https://github.com/teandt/bookmeter_crowler/security/code-scanning/1](https://github.com/teandt/bookmeter_crowler/security/code-scanning/1)

Add an explicit `permissions` block to `.github/workflows/build.yml` at the workflow root so all jobs inherit least-privilege defaults unless overridden.  
Best single fix here (without changing functionality) is:

- Add:
  - `permissions:`
  - `  contents: read`

Place it after the trigger section (`on:` block) and before `jobs:`. This satisfies CodeQL and documents intended token scope while keeping behavior unchanged for checkout/scan usage shown.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
